### PR TITLE
Missing 'delivery' parameter in GET xss scans results

### DIFF
--- a/XssMap.py
+++ b/XssMap.py
@@ -284,6 +284,7 @@ class XssMap(object):
             this_param = {}
             this_param['name'] = param['name']
             this_param['value'] = param['value']
+            this_param['delivery'] = param['delivery']
             this_param['reflect_contexts'] = ['general']  # Implemented as wildcard context
             these_scan_parameters.params_reflected.append(this_param)
 


### PR DESCRIPTION
running an xss-only GET scan fails with the error:

    Traceback (most recent call last):
      File "XssMap.py", line 348, in <module>
        output_data = XSS_MAP.assess_GET_request(request_url)
      File "XssMap.py", line 86, in assess_GET_request
        xss_scan_results = self.__xss_scan_all_GET_params(target_url)
      File "XssMap.py", line 290, in __xss_scan_all_GET_params
         return self.__xss_scan(these_scan_parameters)
      File "XssMap.py", line 333, in __xss_scan
        scan_results = self.xss_scanner.run()
       File "/home/user/prj/xssmap/XssScanner.py", line 283, in run
         result['deliver'] = param_reflected['delivery']
    KeyError: 'delivery'

this patch solves the issue